### PR TITLE
Ensure Ansible installed with Python3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,26 @@ env:
   REGISTRY_NAME: ghcr.io
   CONTAINER_NAME: mmul-it/kpa-marp-pandoc
   CONTAINER_VERSION: latest
+  PACKER_VERSION: 1.9.2
 
 on: [push]
 
 jobs:
+  packer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Get packer
+        run: |
+          packer --version || curl -fSL https://releases.hashicorp.com/packer/${{ env.PACKER_VERSION }}/packer_${{ env.PACKER_VERSION }}_linux_amd64.zip \
+          | gunzip -> /usr/bin/packer
+          chmod u+x /usr/bin/packer
+          /usr/bin/packer -version
   build_and_push:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build the container image
       run: docker build . --file Dockerfile --tag ${REGISTRY_NAME}/${CONTAINER_NAME}:${CONTAINER_VERSION}
     - name: Login into the container registry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.5.0
+    hooks:
+        - id: commitlint
+          stages: [commit-msg]
+          additional_dependencies: ['@commitlint/config-conventional']
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.3
+    hooks:
+      - id: check-github-workflows
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: markdownlint
+      - id: shellcheck
+      - id: shfmt
+      - id: script-must-have-extension

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,9 @@ repos:
       - id: shellcheck
       - id: shfmt
       - id: script-must-have-extension
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: ""

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,112 @@
+{
+  "version": "1.4.29",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2023-08-04T07:57:18Z"
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};

--- a/default.auto.pkvars.hcl
+++ b/default.auto.pkvars.hcl
@@ -1,0 +1,1 @@
+source_image="docker.io/ubuntu:22.04"

--- a/image_requirements.txt
+++ b/image_requirements.txt
@@ -1,0 +1,4 @@
+yamllint==1.31.0
+ansible==8.2.0
+ansible-core==2.15.2
+ansible-lint==6.17.2

--- a/packer.pkr.hcl
+++ b/packer.pkr.hcl
@@ -1,0 +1,85 @@
+variable "source_image" {
+  type    = string
+  default = "docker.io/ubuntu:focal"
+  # Selecting ubuntu:focal instead of ubuntu:22.04 because of glibc problem on my podman
+  # See https://stackoverflow.com/a/73701049/2707870
+  description = "Base image to extend."
+}
+
+variable "base_packages" {
+  type        = list(string)
+  description = "Base OS packages to be added to the image."
+  default = [
+    "python3.9",
+    "python3-pip",
+    "curl",
+    "git"
+    // "rubygems",
+    // "pandoc",
+    // "texlive",
+    // "texlive-base",
+    // "texlive-binaries",
+    // "texlive-fonts-recommended",
+    // "texlive-latex-base",
+    // "texlive-latex-extra",
+    // "texlive-latex-recommended",
+    // "texlive-pictures",
+    // "texlive-plain-generic",
+    // "texlive-xetex"
+  ]
+}
+
+variable "google_signing_key_url" {
+  description = "URL of the Google apt repo signing key"
+  type        = string
+  default     = "https://dl.google.com/linux/linux_signing_key.pub"
+}
+source "docker" "default" {
+  image  = var.source_image
+  commit = true
+  changes = [
+    "ENV TZ=Etc/UTC",
+    "ENV DEBIAN_FRONTEND=noninteractive"
+  ]
+}
+
+data "http" "google_signing_key" {
+  url = var.google_signing_key_url
+}
+
+build {
+  sources = ["source.docker.default"]
+  provisioner "shell" {
+    inline = [
+      "apt-get update -qq",
+      "apt-get install -qq gpg gnupg2"
+    ]
+  }
+
+  # Add the python requirements for the image
+  provisioner "file" {
+    source      = "image_requirements.txt"
+    destination = "/image_requirements.txt"
+  }
+  # Add the google signing key for the chrome browser we need later.
+  provisioner "file" {
+    content     = data.http.google_signing_key.body
+    destination = "/google.gpg"
+  }
+  provisioner "file" {
+    content     = "deb [signed-by=/usr/local/share/keyrings/google.gpg] http://dl.google.com/linux/chrome/deb/ stable main"
+    destination = "/etc/apt/sources.list.d/google-chrome.list"
+  }
+
+  # Package installation
+  provisioner "shell" {
+    inline = [
+      "echo \"${data.http.google_signing_key.body}\" | apt-key add -",
+      // "curl -sL https://deb.nodesource.com/setup_18.x | bash -",
+      "DEBIAN_FRONTEND=noninteractive apt-get install -y ${join(" ", var.base_packages)}",
+      # Add pip packages
+      "python3.9 -m pip install -r /image_requirements.txt",
+      "npm install -g @marp-team/marp-cli"
+    ]
+  }
+}


### PR DESCRIPTION

This fixes https://github.com/mmul-it/kpa/issues/5

This PR contains:

1. Packer template (written to correspond to Dockerfile) -- however ensures pip3 with python3.9 is invoked when installing ansible
3. pre-commit hooks and sundry

The packer template diverges from the Dockerfile in that it makes greater use of declarative versions -- e.g. the requirements.txt file for the image, etc.