### PR TITLE
Manage container tags and releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Env
-      run: env
     - name: Check whether github.ref_type is branch or tag
       run: if [ "${{ github.ref_type }}" == 'branch' ];
             then
@@ -21,8 +19,11 @@ jobs:
              echo "CONTAINER_VERSION=$(echo ${{ github.ref_name }})" >> ${GITHUB_ENV};
            fi
     - name: Build the container image
-      run: docker build . --file Dockerfile --tag ${REGISTRY_NAME}/${CONTAINER_NAME}:${CONTAINER_VERSION}
+      run: docker build .
+             --file Dockerfile
+             --tag ${REGISTRY_NAME}/${CONTAINER_NAME}:${CONTAINER_VERSION}
+             --tag ${REGISTRY_NAME}/${CONTAINER_NAME}:latest
     - name: Login into the container registry
       run: echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u ${{ vars.GHCR_USER }} --password-stdin
     - name: Push the image into the container registry
-      run: docker push ${REGISTRY_NAME}/${CONTAINER_NAME}:${CONTAINER_VERSION}
+      run: docker push --all-tags ${REGISTRY_NAME}/${CONTAINER_NAME}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ name: Create kpa-marp-pandoc container image
 env:
   REGISTRY_NAME: ghcr.io
   CONTAINER_NAME: mmul-it/kpa-marp-pandoc
-  CONTAINER_VERSION: latest
 
 on: [push]
 
@@ -12,6 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Env
+      run: env
+    - name: Check whether github.ref_type is branch or tag
+      run: if [ "${{ github.ref_type }}" == 'branch' ];
+            then
+             echo "CONTAINER_VERSION=$(echo ${{ github.sha }} | cut -c 1-12)" >> ${GITHUB_ENV};
+            else
+             echo "CONTAINER_VERSION=$(echo ${{ github.ref_name }})" >> ${GITHUB_ENV};
+           fi
     - name: Build the container image
       run: docker build . --file Dockerfile --tag ${REGISTRY_NAME}/${CONTAINER_NAME}:${CONTAINER_VERSION}
     - name: Login into the container registry

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: Create kpa-marp-pandoc container image
 
 env:
-  REGISTRY_NAME: ghcr.io
-  CONTAINER_NAME: mmul-it/kpa-marp-pandoc
+  REGISTRY_GHCR: ghcr.io/mmul-it
+  REGISTRY_QUAY: quay.io/mmul
+  CONTAINER_NAME: kpa-marp-pandoc
 
 on: [push]
 
@@ -21,9 +22,15 @@ jobs:
     - name: Build the container image
       run: docker build .
              --file Dockerfile
-             --tag ${REGISTRY_NAME}/${CONTAINER_NAME}:${CONTAINER_VERSION}
-             --tag ${REGISTRY_NAME}/${CONTAINER_NAME}:latest
-    - name: Login into the container registry
-      run: echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u ${{ vars.GHCR_USER }} --password-stdin
-    - name: Push the image into the container registry
-      run: docker push --all-tags ${REGISTRY_NAME}/${CONTAINER_NAME}
+             --tag ${REGISTRY_GHCR}/${CONTAINER_NAME}:${CONTAINER_VERSION}
+             --tag ${REGISTRY_GHCR}/${CONTAINER_NAME}:latest
+             --tag ${REGISTRY_QUAY}/${CONTAINER_NAME}:${CONTAINER_VERSION}
+             --tag ${REGISTRY_QUAY}/${CONTAINER_NAME}:latest
+    - name: Login into the GitHub Container Registry
+      run: echo "${{ secrets.GHCR_TOKEN }}" | docker login ${REGISTRY_GHCR} --username "${{ vars.GHCR_USER }}" --password-stdin
+    - name: Login into the Quay Container Registry
+      run: echo "${{ secrets.QUAY_ROBOT_TOKEN }}" | docker login ${REGISTRY_QUAY} --username "${{ vars.QUAY_ROBOT_NAME }}" --password-stdin
+    - name: Push the image into the GitHub Container Registry
+      run: docker push --all-tags ${REGISTRY_GHCR}/${CONTAINER_NAME}
+    - name: Push the image into the Quay Container Registry
+      run: docker push --all-tags ${REGISTRY_QUAY}/${CONTAINER_NAME}


### PR DESCRIPTION
This merge covers the release management to:

- Set for each commit a tag with the first 12 chars of the SHA commit if it's a branch commit or with the ref name if it's a tag/release.
- Push on both ghcr.io and quay.io.